### PR TITLE
Default proxy from environment

### DIFF
--- a/request/send.js
+++ b/request/send.js
@@ -4,11 +4,20 @@ var https = require('https')
 var stream = require('stream')
 var crypto = require('crypto')
 var log = require('../utils/log')
+var proxy = require('./proxy')
 
 
 module.exports = () => ({options, body}) => new Promise((resolve, reject) => {
 
   var id = crypto.randomBytes(20).toString('hex')
+
+  var proxyURL = /https/.test(options.protocol)
+    ? (process.env.https_proxy || process.env.HTTPS_PROXY)
+    : (process.env.http_proxy || process.env.HTTP_PROXY)
+
+  if (proxyURL) {
+    ({options} = proxy(proxyURL)({options}))
+  }
 
   var req =
     (/https/.test(options.protocol) ? https : http)

--- a/response/status.js
+++ b/response/status.js
@@ -7,11 +7,10 @@ module.exports = () => ({options, res, body, raw}) => {
 
   log({status: {res, body, raw}})
 
-  if (/^(2|3)/.test(res.statusCode)) {
-    return {options, res, body, raw}
-  }
-  else if (/^(4|5)/.test(res.statusCode)) {
+  if (/^(4|5)/.test(res.statusCode)) {
     throw error({options, res, body, raw})
+  } else {
+    return {options, res, body, raw}
   }
 
 }

--- a/test/client.js
+++ b/test/client.js
@@ -36,6 +36,20 @@ describe('client', () => {
     t.deepStrictEqual(body, {server: 'hi'})
   })
 
+  it('without url', async () => {
+    var {res, body} = await request({
+      method: 'POST',
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: 5000,
+      path: '',
+      json: {client: 'hey'},
+    })
+    t.equal(res.statusCode, 200)
+    t.equal(res.statusMessage, 'OK')
+    t.deepStrictEqual(body, {server: 'hi'})
+  })
+
   after((done) => server.close(done))
 
 })

--- a/test/request/proxy.js
+++ b/test/request/proxy.js
@@ -37,4 +37,18 @@ describe('proxy', () => {
     })
   })
 
+  it('as object', () => {
+    var {protocol, hostname, port, path} = url.parse('http://resource.com')
+    var {options} = Request.proxy({ protocol: 'https:', hostname: 'proxy.com' })
+      ({options: {protocol, hostname, port, path, headers: {}}})
+
+    t.deepEqual(options, {
+      protocol: 'https:',
+      hostname: 'proxy.com',
+      port: null,
+      path: 'http://resource.com/',
+      headers: {host: 'resource.com'}
+    })
+  })
+
 })

--- a/test/request/qs.js
+++ b/test/request/qs.js
@@ -10,6 +10,22 @@ var Request = {
 
 describe('qs', () => {
 
+  it('undefined', () => {
+    t.equal(
+      Request.qs()({options: {path: '/'}}).options.path,
+      '/',
+      'ignore'
+    )
+  })
+
+  it('undefined + url', () => {
+    t.equal(
+      Request.qs()({options: {path: '/?c=1:2'}}).options.path,
+      '/?c=1:2',
+      'ignore'
+    )
+  })
+
   it('string', () => {
     t.equal(
       Request.qs('a=!(1)&b=2+3')({options: {path: '/'}}).options.path,
@@ -23,6 +39,22 @@ describe('qs', () => {
       Request.qs('a=!(1)&b=2+3')({options: {path: '/?c=1:2'}}).options.path,
       '/?c=1:2&a=!(1)&b=2+3',
       'prepend and do not encode'
+    )
+  })
+
+  it('empty object', () => {
+    t.equal(
+      Request.qs({})({options: {path: '/'}}).options.path,
+      '/',
+      'ignore'
+    )
+  })
+
+  it('empty object + url', () => {
+    t.equal(
+      Request.qs({})({options: {path: '/?b=2:3&c=$5'}}).options.path,
+      '/?b=2%3A3&c=%245',
+      'ignore'
     )
   })
 

--- a/test/request/send.js
+++ b/test/request/send.js
@@ -135,6 +135,109 @@ describe('send', () => {
     }
   })
 
+  describe('proxy from environment', () => {
+    var proxyServer
+
+    before(async () => {
+      await new Promise((resolve) => {
+        proxyServer = http.createServer(credentials)
+        proxyServer.on('request', (req, res) => {
+          t.ok(/https?:\/\/request:8080\//.test(req.url), 'should be absolute URL')
+          res.writeHead(200, 'PROXY')
+          res.end()
+        })
+        proxyServer.listen(5003, resolve)
+      })
+    })
+
+    it('http_proxy', async () => {
+      process.env.http_proxy = 'http://localhost:5003'
+      try {
+        var {res} = await Request.send({
+          options: {
+            protocol: 'http:',
+            hostname: 'request',
+            port: 8080,
+            method: 'GET',
+            path: '/',
+            headers: {},
+            timeout: 5000
+          }
+        })
+        t.equal(res.statusCode, 200)
+        t.equal(res.statusMessage, 'PROXY')
+      } finally {
+        delete process.env.http_proxy
+      }
+    })
+
+    it('HTTP_PROXY', async () => {
+      process.env.HTTP_PROXY = 'http://localhost:5003'
+      try {
+        var {res} = await Request.send({
+          options: {
+            protocol: 'http:',
+            hostname: 'request',
+            port: 8080,
+            method: 'GET',
+            path: '/',
+            headers: {},
+            timeout: 5000
+          }
+        })
+        t.equal(res.statusCode, 200)
+        t.equal(res.statusMessage, 'PROXY')
+      } finally {
+        delete process.env.HTTP_PROXY
+      }
+    })
+
+    it('https_proxy', async () => {
+      process.env.https_proxy = 'http://localhost:5003'
+      try {
+        var {res} = await Request.send({
+          options: {
+            protocol: 'https:',
+            hostname: 'request',
+            port: 8080,
+            method: 'GET',
+            path: '/',
+            headers: {},
+            timeout: 5000
+          }
+        })
+        t.equal(res.statusCode, 200)
+        t.equal(res.statusMessage, 'PROXY')
+      } finally {
+        delete process.env.https_proxy
+      }
+    })
+
+    it('HTTPS_PROXY', async () => {
+      process.env.HTTPS_PROXY = 'http://localhost:5003'
+      try {
+        var {res} = await Request.send({
+          options: {
+            protocol: 'https:',
+            hostname: 'request',
+            port: 8080,
+            method: 'GET',
+            path: '/',
+            headers: {},
+            timeout: 5000
+          }
+        })
+        t.equal(res.statusCode, 200)
+        t.equal(res.statusMessage, 'PROXY')
+      } finally {
+        delete process.env.HTTPS_PROXY
+      }
+    })
+
+    after((done) => proxyServer.close(done))
+
+  })
+
   after((done) => httpServer.close(() => httpsServer.close(done)))
 
 })


### PR DESCRIPTION
I'm using grant in an environment where I need every request to go through an internal proxy server. The request for profile_url is done with request-compose, which currently does not use the `http_proxy` / `https_proxy` environment variables and therefore the OAuth2 / Open ID Connect flow fails.

This PR adds detection of those environment variables to .send(). This needs to be done just before sending (and not in `defaults()` or something), because the protocol for the request could change at any time before that and the correct env var has to be used.

Added some other test-cases (and a small change to `response/status.js`) to increase test coverage a bit.