### PR TITLE
Fix Node type imports

### DIFF
--- a/compose.d.ts
+++ b/compose.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="node" />
 import '@types/node'
-import * as http from 'node:http'
-import * as https from 'node:https'
-import * as stream from 'node:stream'
+import * as http from 'http'
+import * as https from 'https'
+import * as stream from 'stream'
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request fixes the Node internal type imports otherwise you get compilation errors with the latest `@types/node` like this:

```
Cannot find module 'node:https' or its corresponding type declarations.
```