### PR TITLE
Add dtslint, fix and improve typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,17 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@types/node": "^15.0.2",
     "coveralls": "^3.1.0",
+    "dtslint": "^4.0.9",
     "mocha": "^7.2.0",
     "nyc": "^15.1.0",
     "qs": "^6.9.4",
     "request-cookie": "^1.0.0",
     "request-logs": "^2.1.3",
     "request-multipart": "^1.0.0",
-    "request-oauth": "^1.0.1"
+    "request-oauth": "^1.0.1",
+    "typescript": "^4.2.4"
   },
   "main": "./compose.js",
   "type": "commonjs",
@@ -41,9 +44,10 @@
     "README.md",
     "package.json"
   ],
-  "types": "compose.d.ts",
+  "types": "types/index.d.ts",
   "scripts": {
-    "test": "npm run test:ci",
+    "dtslint": "dtslint types",
+    "test": "npm run dtslint && npm run test:ci",
     "test:ci": "npx mocha --recursive",
     "test:cov": "npx nyc --reporter=lcov --reporter=text-summary mocha -- --recursive"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="node" />
 import '@types/node'
-import * as http from 'node:http'
-import * as https from 'node:https'
-import * as stream from 'node:stream'
+import * as http from 'http'
+import * as https from 'https'
+import * as stream from 'stream'
 
 // ----------------------------------------------------------------------------
 
@@ -14,7 +14,7 @@ interface NodeCoreHttpOptions {
   /**
    * Agent
    */
-  agent?: undefined | boolean | https.Agent | http.Agent
+  agent?: boolean | https.Agent | http.Agent
   /**
    * Basic authentication
    */
@@ -584,36 +584,36 @@ export interface StreamResponse {
 /**
  * Functional composition
  */
-declare function compose (functions?: any): (options?: any) => Promise<any>
+declare function compose(...functions: any): (options?: any) => Promise<any>
 
 /**
  * Functional composition
  */
-declare module compose {
+declare namespace compose {
   /**
    * Request middlewares
    */
-  export const Request: RequestMiddlewares
+  const Request: RequestMiddlewares
   /**
    * Response middlewares
    */
-  export const Response: ResponseMiddlewares
+  const Response: ResponseMiddlewares
   /**
    * Client composition
    */
-  export function client (options: RequestOptions): Promise<ClientResponse>
+  function client(options: RequestOptions): Promise<ClientResponse>
   /**
    * Buffer composition
    */
-  export function buffer (options: RequestOptions): Promise<BufferResponse>
+  function buffer(options: RequestOptions): Promise<BufferResponse>
   /**
    * Stream composition
    */
-  export function stream (options: RequestOptions): Promise<StreamResponse>
+  function stream(options: RequestOptions): Promise<StreamResponse>
   /**
    * Extend instance
    */
-  export function extend (options: ExtendMiddlewares): any /*FIX*/
+  function extend(options: ExtendMiddlewares): any /*FIX*/
 }
 
 export default compose

--- a/types/index.test.ts
+++ b/types/index.test.ts
@@ -1,0 +1,23 @@
+import compose from 'index'
+
+const { Request, Response } = compose
+
+const run = async () => {
+  try {
+    const { res, body } = await compose(
+      Request.defaults({headers: {'user-agent': 'request-compose'}}),
+      Request.url('https://api.github.com/users/simov'),
+      Request.send(),
+      Response.buffer(),
+      Response.string(),
+      Response.parse(),
+    )()
+    console.log(res.statusCode, res.statusMessage)
+    console.log(res.headers['x-ratelimit-remaining'])
+    console.log(body)
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+run()

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": ["es6", "ES2020"],
+      "target": "ES2015",
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "noEmit": true,
+
+      // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
+      // If the library is global (cannot be imported via `import` or `require`), leave this out.
+      "baseUrl": ".",
+      "paths": { "request-compose": ["index.d.ts"] }
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "dtslint/dtslint.json", // Or "dtslint/dt.json" if on DefinitelyTyped
+  "rules": {
+      "indent": [true, "spaces"],
+      "semicolon": false,
+      "no-redundant-jsdoc": false,
+      "ban-types": false
+  }
+}


### PR DESCRIPTION
This is a follow-up and closes https://github.com/simov/request-compose/pull/9 and adds [dtslint](https://github.com/Microsoft/dtslint) which checks and tests TypeScript definitions. It will now run with every `npm test`. 

Also fixes the error mentioned in the related issues and some usage and declaration improvements suggested by the linter.