### PR TITLE
fix: don't import node type for ts 4.7.2

### DIFF
--- a/compose.d.ts
+++ b/compose.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import '@types/node'
+
 import * as http from 'http'
 import * as https from 'https'
 import * as stream from 'stream'


### PR DESCRIPTION
Make request-compose work with 4.7.0-dev.20220325+

> import '@types/node' is not a supported form of importing a types package -- if that ever worked, it was because of a bug. The /// <reference types="node" /> is the correct way to do this; I don't know why they added the incorrect import on the following line.

https://github.com/microsoft/TypeScript/issues/49349