### PR TITLE
Do not pass through invalid auth

### DIFF
--- a/request/defaults.js
+++ b/request/defaults.js
@@ -40,6 +40,13 @@ var options = [
   'highWaterMark',
 ]
 
+var isValid = (option, value) => {
+  if (option === 'auth') {
+    return typeof value === 'string'
+  } 
+  return true
+}
+
 
 module.exports = (_args = {}) => (args = _args) => {
 
@@ -54,11 +61,12 @@ module.exports = (_args = {}) => (args = _args) => {
   }
 
   return {
-    options: options.reduce((http, option) => (
-      defaults[option] !== undefined ? http[option] = defaults[option] :
-      args[option] !== undefined ? http[option] = args[option] :
-      null,
-      http
-    ), {})
+    options: options.reduce((http, option) => {
+      var value = defaults[option] ?? args[option]
+      if (value !== undefined && isValid(option, value)) {
+        http[option] = value
+      }
+      return http
+    }, {})
   }
 }

--- a/request/defaults.js
+++ b/request/defaults.js
@@ -2,7 +2,8 @@
 var options = [
   // https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_http_request_options_callback
   'agent',
-  'auth',
+  // conflicts with our `auth` option and handled in auth.js
+  // 'auth',
   'createConnection',
   'defaultPort',
   'family',
@@ -40,13 +41,6 @@ var options = [
   'highWaterMark',
 ]
 
-var isValid = (option, value) => {
-  if (option === 'auth') {
-    return typeof value === 'string'
-  } 
-  return true
-}
-
 
 module.exports = (_args = {}) => (args = _args) => {
 
@@ -61,12 +55,11 @@ module.exports = (_args = {}) => (args = _args) => {
   }
 
   return {
-    options: options.reduce((http, option) => {
-      var value = defaults[option] ?? args[option]
-      if (value !== undefined && isValid(option, value)) {
-        http[option] = value
-      }
-      return http
-    }, {})
+    options: options.reduce((http, option) => (
+      defaults[option] !== undefined ? http[option] = defaults[option] :
+      args[option] !== undefined ? http[option] = args[option] :
+      null,
+      http
+    ), {})
   }
 }

--- a/test/request/defaults.js
+++ b/test/request/defaults.js
@@ -58,6 +58,28 @@ describe('defaults', () => {
     )
   })
 
+  it('should accept string `auth`', () => {
+    var args = {
+      auth: 'auth'
+    }
+    t.equal(
+      Request.defaults(args)().options.auth,
+      'auth',
+      'should include `auth`'
+    )
+  })
+
+  it('should not accept `auth` if it is not a string', () => {
+    var args = {
+      auth: { user: 'user', pass: 'pass' }
+    }
+    t.equal(
+      Request.defaults(args)().options.auth,
+      undefined,
+      'should not include none string auth'
+    )
+  })
+
   it('filter out non http.request options', () => {
     t.equal(
       Request.defaults()().options.json,

--- a/test/request/defaults.js
+++ b/test/request/defaults.js
@@ -58,18 +58,8 @@ describe('defaults', () => {
     )
   })
 
-  it('should accept string `auth`', () => {
-    var args = {
-      auth: 'auth'
-    }
-    t.equal(
-      Request.defaults(args)().options.auth,
-      'auth',
-      'should include `auth`'
-    )
-  })
 
-  it('should not accept `auth` if it is not a string', () => {
+  it('should not accept `auth`', () => {
     var args = {
       auth: { user: 'user', pass: 'pass' }
     }


### PR DESCRIPTION
Follow up to https://github.com/simov/grant/pull/308

At first I just ignored it if it wasn't a string, but actually I think it makes sense to never pass it through given the lib will always expect `auth` to be an object and handle that?